### PR TITLE
Fix base_frame_offset uninitialized

### DIFF
--- a/clearpath_mecanum_drive_controller/include/clearpath_mecanum_drive_controller/clearpath_mecanum_drive_controller.hpp
+++ b/clearpath_mecanum_drive_controller/include/clearpath_mecanum_drive_controller/clearpath_mecanum_drive_controller.hpp
@@ -26,11 +26,11 @@
 #include "controller_interface/chainable_controller_interface.hpp"
 #include "clearpath_mecanum_drive_controller/odometry.hpp"
 #include "clearpath_mecanum_drive_controller/visibility_control.h"
-#include "clearpath_mecanum_drive_controller_parameters.hpp"
+#include <clearpath_mecanum_drive_controller/clearpath_mecanum_drive_controller_parameters.hpp>
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 #include "rclcpp_lifecycle/state.hpp"
-#include "realtime_tools/realtime_buffer.h"
-#include "realtime_tools/realtime_publisher.h"
+#include "realtime_tools/realtime_buffer.hpp"
+#include "realtime_tools/realtime_publisher.hpp"
 #include "std_srvs/srv/set_bool.hpp"
 
 #include "control_msgs/msg/mecanum_drive_controller_state.hpp"

--- a/clearpath_mecanum_drive_controller/include/clearpath_mecanum_drive_controller/odometry.hpp
+++ b/clearpath_mecanum_drive_controller/include/clearpath_mecanum_drive_controller/odometry.hpp
@@ -16,8 +16,8 @@
 #define CLEARPATH_MECANUM_DRIVE_CONTROLLER__ODOMETRY_HPP_
 
 #include "geometry_msgs/msg/twist.hpp"
-#include "realtime_tools/realtime_buffer.h"
-#include "realtime_tools/realtime_publisher.h"
+#include "realtime_tools/realtime_buffer.hpp"
+#include "realtime_tools/realtime_publisher.hpp"
 
 #define PLANAR_POINT_DIM 3
 

--- a/clearpath_mecanum_drive_controller/src/clearpath_mecanum_drive_controller.cpp
+++ b/clearpath_mecanum_drive_controller/src/clearpath_mecanum_drive_controller.cpp
@@ -107,7 +107,9 @@ controller_interface::CallbackReturn MecanumDriveController::on_configure(
       params_.command_joint_names.size(), state_joint_names_.size());
     return CallbackReturn::FAILURE;
   }
-
+  
+  odometry_.init(
+    get_node()->now(), {params_.kinematics.base_frame_offset.x, params_.kinematics.base_frame_offset.y, params_.kinematics.base_frame_offset.theta});
   // Set wheel params for the odometry computation
   odometry_.setWheelsParams(
     params_.kinematics.sum_of_robot_center_projection_on_X_Y_axis,


### PR DESCRIPTION
The position and twist sometimes would be in the 10^xxx range, found out that the base_frame_offset was unitialized and sometimes wasn't 0, so the calculations weren't correct.

This PR adds a call to the init function that was unused and sets the base_frame_offset.

(also fixed some include deprecation warnings)

Log of one faulty run:

```
ros2 topic echo /mirte_base_controller/odom
header:
  stamp:
    sec: 1744034898
    nanosec: 822650757
  frame_id: odom
child_frame_id: base_link
pose:
  pose:
    position:
      x: -6.913736096642743e+251
      y: -5.607148405768878e+250
      z: 0.0
    orientation:
      x: 0.0
      y: 0.0
      z: 0.049610444530243034
      w: 0.9987686437776827
  covariance:
  - 0.0
  - 0.0

```

Tested it on a robot, did not occur anymore. 